### PR TITLE
fix(dashboard): fix wordings for project types and its labels

### DIFF
--- a/app/components/ItemSelectInput/index.tsx
+++ b/app/components/ItemSelectInput/index.tsx
@@ -67,7 +67,7 @@ const USER_GROUPS = gql`
 query UserGroupOptions($search: String, $offset: Int!, $limit: Int!) {
     contributorUserGroups(
         filters: {
-            name: $search
+            name: {iContains: $search}
         }
         pagination: {
             limit: $limit,

--- a/app/components/ItemSelectInput/index.tsx
+++ b/app/components/ItemSelectInput/index.tsx
@@ -67,7 +67,7 @@ const USER_GROUPS = gql`
 query UserGroupOptions($search: String, $offset: Int!, $limit: Int!) {
     contributorUserGroups(
         filters: {
-            name: {iContains: $search}
+            name: $search
         }
         pagination: {
             limit: $limit,

--- a/app/views/StatsBoard/index.tsx
+++ b/app/views/StatsBoard/index.tsx
@@ -441,8 +441,7 @@ function StatsBoard(props: Props) {
     )?.totalArea;
     */
     const streetTotalArea = areaSwipedByProjectType?.find(
-        // TODO: Change the type to street
-        (project) => project.projectType === COMPLETENESS,
+        (project) => project.projectType === STREET,
     )?.totalArea;
 
     const completenessTotalArea = areaSwipedByProjectType?.find(
@@ -466,8 +465,7 @@ function StatsBoard(props: Props) {
     )?.totalSwipes;
 
     const streetTotalSwipes = swipeByProjectType?.find(
-        // TODO: Change the type to street
-        (project) => project.projectType === COMPLETENESS,
+        (project) => project.projectType === STREET,
     )?.totalSwipes;
 
     const completenessTotalSwipes = swipeByProjectType?.find(
@@ -666,7 +664,7 @@ function StatsBoard(props: Props) {
                                 Area Swipes
                             </div>
                         )}
-                        subHeading="Find features"
+                        subHeading="Find Features"
                         variant="stat"
                     />
                     <InformationCard
@@ -782,7 +780,7 @@ function StatsBoard(props: Props) {
                         )}
                         label={(
                             <div className={styles.infoLabel}>
-                                Streets Viewed
+                                Street Viewed
                             </div>
                         )}
                         subHeading="View Streets"

--- a/app/views/StatsBoard/index.tsx
+++ b/app/views/StatsBoard/index.tsx
@@ -666,7 +666,7 @@ function StatsBoard(props: Props) {
                                 Area Swipes
                             </div>
                         )}
-                        subHeading="Find"
+                        subHeading="Find features"
                         variant="stat"
                     />
                     <InformationCard
@@ -689,7 +689,7 @@ function StatsBoard(props: Props) {
                                 Features Checked
                             </div>
                         )}
-                        subHeading="Validate"
+                        subHeading="Validate Footprints"
                         variant="stat"
                     />
                     <InformationCard
@@ -721,7 +721,7 @@ function StatsBoard(props: Props) {
                                 Scene Compared
                             </div>
                         )}
-                        subHeading="Compare"
+                        subHeading="Compare Dates"
                         variant="stat"
                     />
                     <InformationCard
@@ -750,10 +750,10 @@ function StatsBoard(props: Props) {
                         )}
                         label={(
                             <div className={styles.infoLabel}>
-                                Completeness
+                                Completeness Checked
                             </div>
                         )}
-                        subHeading="Completeness"
+                        subHeading="Check Completeness"
                         variant="stat"
                     />
                     <InformationCard
@@ -782,10 +782,10 @@ function StatsBoard(props: Props) {
                         )}
                         label={(
                             <div className={styles.infoLabel}>
-                                Streets Covered
+                                Streets Viewed
                             </div>
                         )}
-                        subHeading="Street"
+                        subHeading="View Streets"
                         variant="stat"
                     />
                     <InformationCard
@@ -806,10 +806,10 @@ function StatsBoard(props: Props) {
                         )}
                         label={(
                             <div className={styles.infoLabel}>
-                                Images Validated
+                                Images Assessed
                             </div>
                         )}
-                        subHeading="Validate Image"
+                        subHeading="Assess Images"
                         variant="stat"
                     />
                 </div>

--- a/app/views/UserDashboard/index.tsx
+++ b/app/views/UserDashboard/index.tsx
@@ -55,7 +55,7 @@ const USER_STATS = gql`
         }
         contributorUserGroups(
             pagination: {limit: $limit, offset: $offset}
-            filters: {firebaseId: $pk}
+            filters: {userFirebaseId: $pk}
         ) {
             results {
                 id

--- a/app/views/UserDashboard/index.tsx
+++ b/app/views/UserDashboard/index.tsx
@@ -55,7 +55,7 @@ const USER_STATS = gql`
         }
         contributorUserGroups(
             pagination: {limit: $limit, offset: $offset}
-            filters: {userFirebaseId: $pk}
+            filters: {firebaseId: $pk}
         ) {
             results {
                 id


### PR DESCRIPTION
## Changes

* Fix labels and subheadings of various project types in stats card in the dashboard
* Add 'STREET' project type in dashboard statistics

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
